### PR TITLE
New manifest.json for compatibility to TB68+

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@ Folder-Account
 ==============
 
 A Thunderbird extension to make managing multiple return addresses easier
+
+
+Adaption for Thunderbird 57+ sponsored by Feddersen Architekten, Berlin Germany

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "name": "Folder Account",
     "author": "Christopher Eykamp",
     "description": "Associate an account or identity with a particular folder",
-    "version": "7.0.1",
+    "version": "8.0",
     "legacy": {
         "type": "xul"
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,16 @@
+{
+    "manifest_version": 2,
+    "applications": {
+        "gecko": {
+            "id": "{C8534C26-F59A-11DA-9804-B622A1EF5492}",
+            "strict_min_version": "68.0"
+        }
+    },
+    "name": "Folder Account",
+    "author": "Christopher Eykamp",
+    "description": "Associate an account or identity with a particular folder",
+    "version": "7.0.1",
+    "legacy": {
+        "type": "xul"
+    }
+}


### PR DESCRIPTION
New Thunderbird API requires migration from `install.rdf` to `manifest.json`. I left `install.rdf` as it is to stay compatible with earlier versions.
Please accept these changes to be compatible to TB68+
Since a customer of ours is paying our time for needed changes we added a line in Readme.md. We hope that's OK with you. If not simply reject that line.

Yours
Stephan