### PR TITLE
Update folderAccount_props.xul

### DIFF
--- a/chrome/content/folderAccount_props.xul
+++ b/chrome/content/folderAccount_props.xul
@@ -299,10 +299,19 @@ var folderAccountProps = {
         //// Now add an event handler for when the user clicks "OK"
 
         // First, grab the current event handler
-        var handler = document.documentElement.getAttribute('ondialogaccept');
+        // var handler = document.documentElement.getAttribute('ondialogaccept');
 
         // And prepend our save function to it...
-        document.documentElement.setAttribute('ondialogaccept','folderAccountProps.saveAccountPrefs();' + handler);
+        // document.documentElement.setAttribute('ondialogaccept','folderAccountProps.saveAccountPrefs();' + handler);
+		
+        // The preceding code no longer works in Thunderbird 68 
+        // (see https://developer.thunderbird.net/add-ons/tb68/changes#less-than-dialog-greater-than-events),
+        // therefore changed preference weren't saved.
+        // This way seems to work fine:
+
+        document.addEventListener("dialogaccept", function(event) {
+        	folderAccountProps.saveAccountPrefs();
+        });
     },
 
 


### PR DESCRIPTION
Fix for changed preferences not getting saved in Thunderbird 68

Having TB 68 freshly installed with a new profile, I found out, the settings of Folder-Account weren't saved at all. After some searching I could identify the deprecation mentioned in https://developer.thunderbird.net/add-ons/tb68/changes#less-than-dialog-greater-than-events to be the culprit. My very simple fix seems to work just fine.

Maybe the guy writing the review at https://addons.thunderbird.net/de/thunderbird/addon/folder-account/reviews/1158986/ had the same problem.

Please review my change

Kind regards